### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ If you discover some new that work, add them here
 ## Tested Environments (meanwhile)
 
 * MacOSX
+* Ubuntu 14.10 (Utopic). Run ```sudo apt-get install android-tools-adb``` first
 
 If you have successfully tested this script on others systems or platforms please let me know or update this list.
 


### PR DESCRIPTION
Added additional tested environment (Ubuntu). One first must install the adb tool, which can be done using the default package manager. 
